### PR TITLE
bump: node20 to node24 in github action

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ Always reference these instructions first and fallback to search or bash command
 
 ### Bootstrap, Build, and Test the Repository
 - Install dependencies: `npm ci` (takes ~4-5 seconds on subsequent runs, up to 30s on first install)
-- Run linter: `npm run lint` (takes <1 second) 
+- Run linter: `npm run lint` (takes <1 second)
 - Run tests: `npm run test` (takes <1 second, 3 tests)
 - Build action: `npm run build` (takes ~8-10 seconds. NEVER CANCEL. Set timeout to 30+ seconds)
 - Format code: `npm run format` (takes <1 second)
@@ -61,7 +61,7 @@ jobs:
 ### Validation Checklist
 After making any code changes, verify:
 - [ ] `npm run lint` passes without errors
-- [ ] `npm run test` shows all 3 tests passing  
+- [ ] `npm run test` shows all 3 tests passing
 - [ ] `npm run build` completes and creates both dist files
 - [ ] `dist/index.js` is ~2.3MB and `dist/cleanup.js` is ~1.9MB
 - [ ] No uncommitted changes after build (dist files should be committed)
@@ -75,7 +75,7 @@ node -e "const yaml = require('js-yaml'); const fs = require('fs'); console.log(
 # Check bundle sizes
 ls -lh dist/
 
-# Verify Node.js compatibility (should be 20.x)
+# Verify Node.js compatibility (should be 24.x)
 node --version
 
 # Test IP detection (will fail in sandbox but shows axios functionality)
@@ -94,7 +94,7 @@ ls -la dist/
 **CRITICAL**: Always use appropriate timeouts to prevent premature command cancellation:
 
 - `npm ci`: 4-5 seconds (cached) to 30 seconds (fresh) → Use 60+ second timeout
-- `npm run lint`: <1 second → Use 30+ second timeout  
+- `npm run lint`: <1 second → Use 30+ second timeout
 - `npm run test`: <1 second → Use 30+ second timeout
 - `npm run build`: 8-10 seconds → Use 30+ second timeout
 - `npm run format`: <1 second → Use 30+ second timeout
@@ -135,7 +135,7 @@ node -e "console.log(require('@actions/core')); console.log(require('@aws-sdk/cl
 ```
 
 ### Required Tools and Dependencies
-- Node.js 20.x (action requires node20 runtime)
+- Node.js 24.x (action requires node24 runtime)
 - npm (included with Node.js)
 - All dependencies defined in package.json
 
@@ -175,7 +175,7 @@ aws-waf-temp-access/
 ### action.yml
 Defines the GitHub Action interface with:
 - Required inputs: id, name, scope, region
-- Node.js 20 runtime specification
+- Node.js 24 runtime specification
 - Main and post-action script references
 
 ### package.json Scripts

--- a/__tests__/action.test.js
+++ b/__tests__/action.test.js
@@ -32,12 +32,12 @@ jest.mock('axios', () => ({
   get: jest.fn(),
 }));
 
-const { 
-  getPublicIP, 
-  createWAFClient, 
+const {
+  getPublicIP,
+  createWAFClient,
   createEC2Client,
   addIPToIPSet,
-  addIPToSecurityGroup 
+  addIPToSecurityGroup
 } = require('../src/index.js');
 
 const core = require('@actions/core');
@@ -50,18 +50,18 @@ describe('aws-waf-temp-access', () => {
   test('action.yml should have correct structure', () => {
     const actionPath = path.join(__dirname, '..', 'action.yml');
     expect(fs.existsSync(actionPath)).toBe(true);
-    
+
     const actionContent = fs.readFileSync(actionPath, 'utf8');
     const action = yaml.load(actionContent);
-    
+
     // Check required fields
     expect(action.name).toBe('aws-waf-temp-access');
     expect(action.description).toBeDefined();
     expect(action.runs).toBeDefined();
-    expect(action.runs.using).toBe('node20');
+    expect(action.runs.using).toBe('node24');
     expect(action.runs.main).toBe('dist/index.js');
     expect(action.runs.post).toBe('dist/cleanup.js');
-    
+
     // Check required inputs
     expect(action.inputs.id).toBeDefined();
     expect(action.inputs.id.required).toBe(false);
@@ -80,14 +80,14 @@ describe('aws-waf-temp-access', () => {
   test('dist files should exist', () => {
     const mainPath = path.join(__dirname, '..', 'dist', 'index.js');
     const cleanupPath = path.join(__dirname, '..', 'dist', 'cleanup.js');
-    
+
     expect(fs.existsSync(mainPath)).toBe(true);
     expect(fs.existsSync(cleanupPath)).toBe(true);
-    
+
     // Check file sizes are reasonable (should be bundled)
     const mainStats = fs.statSync(mainPath);
     const cleanupStats = fs.statSync(cleanupPath);
-    
+
     expect(mainStats.size).toBeGreaterThan(1000000); // At least 1MB (bundled)
     expect(cleanupStats.size).toBeGreaterThan(1000000); // At least 1MB (bundled)
   });
@@ -95,13 +95,13 @@ describe('aws-waf-temp-access', () => {
   test('package.json should have correct dependencies', () => {
     const packagePath = path.join(__dirname, '..', 'package.json');
     const packageContent = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
-    
+
     // Check required dependencies
     expect(packageContent.dependencies['@actions/core']).toBeDefined();
     expect(packageContent.dependencies['@aws-sdk/client-wafv2']).toBeDefined();
     expect(packageContent.dependencies['@aws-sdk/client-ec2']).toBeDefined();
     expect(packageContent.dependencies['axios']).toBeDefined();
-    
+
     // Check dev dependencies
     expect(packageContent.devDependencies['@vercel/ncc']).toBeDefined();
   });
@@ -109,7 +109,7 @@ describe('aws-waf-temp-access', () => {
   test('createWAFClient should return WAFv2Client instance', () => {
     const region = 'us-east-1';
     const client = createWAFClient(region);
-    
+
     expect(mockWAFv2Client).toHaveBeenCalledWith({ region });
     expect(client).toBeDefined();
   });
@@ -117,7 +117,7 @@ describe('aws-waf-temp-access', () => {
   test('createEC2Client should return EC2Client instance', () => {
     const region = 'us-west-2';
     const client = createEC2Client(region);
-    
+
     expect(mockEC2Client).toHaveBeenCalledWith({ region });
     expect(client).toBeDefined();
   });
@@ -125,9 +125,9 @@ describe('aws-waf-temp-access', () => {
   test('getPublicIP should return IP from primary service', async () => {
     const mockIP = '192.168.1.1';
     axios.get.mockResolvedValueOnce({ data: `  ${mockIP}  ` });
-    
+
     const result = await getPublicIP();
-    
+
     expect(axios.get).toHaveBeenCalledWith('https://api.ipify.org?format=text', {
       timeout: 10000,
     });
@@ -139,9 +139,9 @@ describe('aws-waf-temp-access', () => {
     axios.get
       .mockRejectedValueOnce(new Error('Primary service failed'))
       .mockResolvedValueOnce({ data: `${mockIP}\n` });
-    
+
     const result = await getPublicIP();
-    
+
     expect(axios.get).toHaveBeenCalledTimes(2);
     expect(axios.get).toHaveBeenNthCalledWith(1, 'https://api.ipify.org?format=text', {
       timeout: 10000,
@@ -156,7 +156,7 @@ describe('aws-waf-temp-access', () => {
     axios.get
       .mockRejectedValueOnce(new Error('Primary service failed'))
       .mockRejectedValueOnce(new Error('Secondary service failed'));
-    
+
     await expect(getPublicIP()).rejects.toThrow('Failed to get public IP: Secondary service failed');
   });
 
@@ -168,12 +168,12 @@ describe('aws-waf-temp-access', () => {
     const groupId = 'sg-123456789';
     const ipAddress = '192.168.1.1';
     const description = 'Test description';
-    
+
     core.info = jest.fn();
     core.saveState = jest.fn();
-    
+
     await addIPToSecurityGroup(mockClient, groupId, ipAddress, description);
-    
+
     expect(mockClient.send).toHaveBeenCalledTimes(1);
     expect(core.saveState).toHaveBeenCalledWith('sg-runner-ip', '192.168.1.1/32');
     expect(core.saveState).toHaveBeenCalledWith('sg-group-id', groupId);
@@ -189,12 +189,12 @@ describe('aws-waf-temp-access', () => {
     };
     const groupId = 'sg-123456789';
     const ipAddress = '10.0.0.0/24';
-    
+
     core.info = jest.fn();
     core.saveState = jest.fn();
-    
+
     await addIPToSecurityGroup(mockClient, groupId, ipAddress); // Test without description (default)
-    
+
     expect(mockClient.send).toHaveBeenCalledTimes(1);
     expect(core.saveState).toHaveBeenCalledWith('sg-runner-ip', '10.0.0.0/24');
     expect(core.saveState).toHaveBeenCalledWith('sg-description', 'Temporary access from GitHub Actions runner');

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ inputs:
     default: 'Temporary access from GitHub Actions runner'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
   post: 'dist/cleanup.js'
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,2 @@
 [tools]
-node = "22"
+node = "24"


### PR DESCRIPTION
GitHub has announced the deprecation of Node 20 on GitHub Actions runners
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

### Changes Made
* **actions.yml:** Updated `node20` to `node24`
* **mise.toml:** Not sure if this needed to be set to `24` instead of `22`
* **.github/copilot-instructions.md:** Updated to reference Node.js `24` instead of `20`
* **tests/action.test.js:** Update to check for `node24`

### Validation Checklist
After making any code changes, verified the following using `Node.js v24.14.1` and `npm v11.12.1`
- [x] npm run lint passes without errors
- [x] npm run test shows all 3 tests passing
- [x] npm run build completes and creates both dist files
- [ ] dist/index.js is ~2.3MB and dist/cleanup.js is ~1.9MB
- [ ] No uncommitted changes after build (dist files should be committed)
- [x] Action YAML structure validates correctly

❗❗ The `dist/index.js` and `dist/cleanup.js` files were created but had differences and were much larger in size `dist/index.js` is ~5.8M and `dist/cleanup.js` is ~5.4M. But the src files did not change so did not check in these changes.
